### PR TITLE
예측 불가능한 에러 시 에러 코드 할당 부분 수정

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -31,7 +31,7 @@ router.get('/application/check', function(req, res, next) {
   }).catch(function(err) {
     winston.debug('어플리 케이션 버전 체크 실패');
 
-    err.errorCode = 302;
+    err.errorCode = err.errorCode || 302;
     next(err);
   });
 });

--- a/routes/users.js
+++ b/routes/users.js
@@ -48,7 +48,7 @@ router.post('/register', function(req, res, next) {
       return next(new helper.makePredictableError(200, 102, 'Sequelize Validation 에서 에러 체크'));
     }
 
-    err.errorCode = 103;
+    err.errorCode = err.errorCode || 103;
     next(err);
   });
 });
@@ -105,7 +105,7 @@ router.post('/check', function(req, res, next) {
   }).catch(function(err) {
     winston.debug('유저 확인 실패');
 
-    err.errorCode = 115;
+    err.errorCode = err.errorCode || 115;
     next(err);
   });
 });

--- a/routes/verse.js
+++ b/routes/verse.js
@@ -56,7 +56,7 @@ router.get('/bible', function(req, res, next) {
   }).catch(function(err) {
     winston.debug('성경 구절 가져오기 실패');
 
-    err.errorCode = 206;
+    err.errorCode = err.errorCode || 206;
     next(err);
   });
 });
@@ -109,7 +109,7 @@ router.post('/bible', function(req, res, next) {
       return next(new helper.makePredictableError(200, 212, 'Sequelize Validation 에서 에러 체크'));
     }
 
-    err.errorCode = 213;
+    err.errorCode = err.errorCode || 213;
     next(err);
   });
 });
@@ -149,7 +149,7 @@ router.get('/randomList', function(req, res, next) {
   }).catch(function(err) {
     winston.debug('랜덤으로 성경 리스트 불러오기 실패');
 
-    err.errorCode = 222;
+    err.errorCode = err.errorCode || 222;
     next(err);
   });
 });
@@ -208,7 +208,7 @@ router.get('/download', function(req, res, next) {
 });
 
 /**
- * 종아요 컨트롤러
+ * 좋아요 컨트롤러
  */
 router.post('/like/:verseId', function(req, res, next) {
   winston.debug('좋아요 컨트롤러 시작');
@@ -263,7 +263,7 @@ router.post('/like/:verseId', function(req, res, next) {
   }).catch(function(err) {
     winston.debug('좋아요 실패');
 
-    err.errorCode = 243;
+    err.errorCode = err.errorCode || 243;
     next(err);
   });
 });
@@ -314,7 +314,7 @@ router.post('/dislike/:likeId', function(req, res, next) {
   }).catch(function(err) {
     winston.debug('좋아요 삭제 실패');
 
-    err.errorCode = 253;
+    err.errorCode = err.errorCode || 253;
     next(err);
   });
 });
@@ -376,7 +376,7 @@ router.post('/report/:verseId', function(req, res, next) {
   }).catch(function(err) {
     winston.debug('신고 실패');
 
-    err.errorCode = 263;
+    err.errorCode = err.errorCode || 263;
     next(err);
   });
 });
@@ -418,7 +418,7 @@ router.get('/myList', function(req, res, next) {
   }).catch(function(err) {
     winston.debug('내 성경 리스트 불러오기 실패');
 
-    err.errorCode = 272;
+    err.errorCode = err.errorCode || 272;
     next(err);
   });
 });
@@ -464,7 +464,7 @@ router.get('/myList/item', function(req, res, next) {
   }).catch(function(err) {
     winston.debug('내 성경 구절 리스트에서 하나의 아이템 가져오기 실패');
 
-    err.errorCode = 283;
+    err.errorCode = err.errorCode || 283;
     next(err);
   });
 });
@@ -514,7 +514,7 @@ router.post('/myList/delete', function(req, res, next) {
   }).catch(function(err) {
     winston.debug('내 성경 구절 지우기 실패');
 
-    err.errorCode = 293;
+    err.errorCode = err.errorCode || 293;
     next(err);
   });
 });


### PR DESCRIPTION
각 컨트롤러에서 catch 하는 부분에서 예측 불가능한 서버 오류의 경우에 대해서
에러 라우터로 보내기 전에 errorCode를 주는데,
기존에 errorCode가 있는 경우에 대해서는 주면 안되기 때문에 수정